### PR TITLE
정적 팩토리 메서드 패턴 적용

### DIFF
--- a/src/main/java/com/study/bookcafe/domain/Borrow.java
+++ b/src/main/java/com/study/bookcafe/domain/Borrow.java
@@ -12,12 +12,14 @@ public class Borrow {
     private long id;                        // 대출 ID
     private Member member;                  // 회원
     private Book book;                      // 도서
+    private LocalDateTime time;             // 대출 시간
     private Period period;                  // 대출 기간
 
-    public Borrow(@NonNull Member member, @NonNull Book book, LocalDateTime from) {
+    public Borrow(@NonNull Member member, @NonNull Book book, @NonNull LocalDateTime from) {
         this.member = member;
         this.book = book;
-        this.period = Period.createPeriod(from, member.getLevel());
+        this.time = from;
+        this.period = Period.of(from.toLocalDate(), member.getLevel());
     }
 
     /**

--- a/src/main/java/com/study/bookcafe/domain/Borrow.java
+++ b/src/main/java/com/study/bookcafe/domain/Borrow.java
@@ -17,7 +17,7 @@ public class Borrow {
     public Borrow(@NonNull Member member, @NonNull Book book, LocalDateTime from) {
         this.member = member;
         this.book = book;
-        this.period = new Period(from);
+        this.period = Period.createPeriod(from, member.getLevel());
     }
 
     /**

--- a/src/main/java/com/study/bookcafe/domain/Level.java
+++ b/src/main/java/com/study/bookcafe/domain/Level.java
@@ -1,19 +1,24 @@
 package com.study.bookcafe.domain;
 
+import lombok.Getter;
+
 public enum Level {
 
-    LIBRARIAN(2, 10,null),          // 사서 회원
-    WORM(1, 5,null),                // 책벌레 회원
-    BASIC(0, 3, WORM);                    // 일반 회원
+    LIBRARIAN(2, 10,null, 2),          // 사서 회원
+    WORM(1, 5,null, 1),                // 책벌레 회원
+    BASIC(0, 3, WORM, 1);                    // 일반 회원
 
     private final int value;                      // 등급 값
     private final int maximumBorrowCount;         // 등급 별 최대 대출 권수
     private final Level next;                     // 다음 등급
+    @Getter
+    private final int borrowPeriod;
 
-    Level(int value, int maximumBorrowCount, Level next) {
+    Level(int value, int maximumBorrowCount, Level next, int borrowPeriod) {
         this.value = value;
         this.maximumBorrowCount = maximumBorrowCount;
         this.next = next;
+        this.borrowPeriod = borrowPeriod;
     }
 
     /**
@@ -25,4 +30,5 @@ public enum Level {
     public boolean isBookBorrowCountLeft(int borrowCount) {
         return this.maximumBorrowCount - borrowCount > 0;
     }
+
 }

--- a/src/main/java/com/study/bookcafe/dto/BorrowDto.java
+++ b/src/main/java/com/study/bookcafe/dto/BorrowDto.java
@@ -18,6 +18,6 @@ public class BorrowDto {
     public BorrowDto(MemberDto member, BookDto book, LocalDateTime from) {
         this.member = member;
         this.book = book;
-        this.period = new Period(from);
+        this.period = Period.createPeriod(from, member.getLevel());
     }
 }

--- a/src/main/java/com/study/bookcafe/dto/BorrowDto.java
+++ b/src/main/java/com/study/bookcafe/dto/BorrowDto.java
@@ -13,11 +13,13 @@ public class BorrowDto {
     private long id;                        // 대출 ID
     private MemberDto member;               // 회원
     private BookDto book;                   // 도서
+    private LocalDateTime time;             // 대출 시간
     private Period period;                  // 대출 기간
 
     public BorrowDto(MemberDto member, BookDto book, LocalDateTime from) {
         this.member = member;
         this.book = book;
-        this.period = Period.createPeriod(from, member.getLevel());
+        this.time = from;
+        this.period = Period.of(from.toLocalDate(), member.getLevel());
     }
 }

--- a/src/main/java/com/study/bookcafe/entity/BorrowEntity.java
+++ b/src/main/java/com/study/bookcafe/entity/BorrowEntity.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Getter
 public class BorrowEntity {
@@ -13,5 +15,7 @@ public class BorrowEntity {
     private MemberEntity member;            // 회원
     @NonNull
     private BookEntity book;                // 도서
+    @NonNull
+    private LocalDateTime time;             // 대출 시간
     private Period period;                  // 대출 기간
 }

--- a/src/main/java/com/study/bookcafe/mapper/BorrowMapper.java
+++ b/src/main/java/com/study/bookcafe/mapper/BorrowMapper.java
@@ -20,8 +20,7 @@ public interface BorrowMapper {
     @Mapping(target = "id", source = "id")
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberToMemberDto"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookToBookDto"})
-//    @Mapping(target = "borrowDate", source = "borrowDate")
-//    @Mapping(target = "returnDate", source = "returnDate")
+    @Mapping(target = "time", source = "time")
     @Mapping(target = "period", source = "period")
     // Borrow -> BorrowDto
     BorrowDto toBorrowDto(Borrow borrow);
@@ -30,8 +29,7 @@ public interface BorrowMapper {
     @Mapping(target = "id", source = "id")
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberDtoToMember"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookDtoToBook"})
-//    @Mapping(target = "borrowDate", source = "borrowDate")
-//    @Mapping(target = "returnDate", source = "returnDate")
+    @Mapping(target = "time", source = "time")
     @Mapping(target = "period", source = "period")
     // BorrowDto -> Borrow
     Borrow toBorrow(BorrowDto borrowDto);
@@ -40,8 +38,7 @@ public interface BorrowMapper {
     @Mapping(target = "id", source = "id")
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberToMemberEntity"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookToBookEntity"})
-//    @Mapping(target = "borrowDate", source = "borrowDate")
-//    @Mapping(target = "returnDate", source = "returnDate")
+    @Mapping(target = "time", source = "time")
     @Mapping(target = "period", source = "period")
     // Borrow -> BorrowEntity
     BorrowEntity toBorrowEntity(Borrow borrow);
@@ -50,8 +47,7 @@ public interface BorrowMapper {
     @Mapping(target = "id", source = "id")
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberEntityToMember"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookEntityToBook"})
-//    @Mapping(target = "borrowDate", source = "borrowDate")
-//    @Mapping(target = "returnDate", source = "returnDate")
+    @Mapping(target = "time", source = "time")
     @Mapping(target = "period", source = "period")
     // BorrowEntity -> Borrow
     Borrow toBorrow(BorrowEntity borrowEntity);

--- a/src/main/java/com/study/bookcafe/vo/Period.java
+++ b/src/main/java/com/study/bookcafe/vo/Period.java
@@ -3,7 +3,7 @@ package com.study.bookcafe.vo;
 import com.study.bookcafe.domain.Level;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @EqualsAndHashCode
 public class Period {
@@ -14,22 +14,22 @@ public class Period {
             - 기본: 1주, 연장 시: 1주 추가, 총 2주
      */
 
-    private final LocalDateTime from;           // 대출 일자
-    private final LocalDateTime to;             // 반납 일자
+    private final LocalDate from;           // 대출 일자
+    private final LocalDate to;             // 반납 일자
 
-    private Period(@NonNull LocalDateTime from, Level level) {
+    private Period(@NonNull LocalDate from, Level level) {
         this.from = from;
         this.to = this.from.plusWeeks(level.getBorrowPeriod());
     }
 
-    public Period(@NonNull LocalDateTime from, @NonNull LocalDateTime to) {
+    public Period(@NonNull LocalDate from, @NonNull LocalDate to) {
         if(from.isAfter(to)) throw new IllegalArgumentException("반납 일자는 대출 일자보다 이후여야 합니다.");
 
         this.from = from;
         this.to = to;
     }
 
-    public static Period createPeriod(@NonNull LocalDateTime from, Level level) {
+    public static Period of(@NonNull LocalDate from, Level level) {
         return new Period(from, level);
     }
 

--- a/src/main/java/com/study/bookcafe/vo/Period.java
+++ b/src/main/java/com/study/bookcafe/vo/Period.java
@@ -1,5 +1,6 @@
 package com.study.bookcafe.vo;
 
+import com.study.bookcafe.domain.Level;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import java.time.LocalDateTime;
@@ -16,9 +17,9 @@ public class Period {
     private final LocalDateTime from;           // 대출 일자
     private final LocalDateTime to;             // 반납 일자
 
-    public Period(@NonNull LocalDateTime from) {
+    private Period(@NonNull LocalDateTime from, Level level) {
         this.from = from;
-        this.to = this.from.plusWeeks(1);
+        this.to = this.from.plusWeeks(level.getBorrowPeriod());
     }
 
     public Period(@NonNull LocalDateTime from, @NonNull LocalDateTime to) {
@@ -27,4 +28,9 @@ public class Period {
         this.from = from;
         this.to = to;
     }
+
+    public static Period createPeriod(@NonNull LocalDateTime from, Level level) {
+        return new Period(from, level);
+    }
+
 }

--- a/src/test/java/com/study/bookcafe/borrow/MapperTest.java
+++ b/src/test/java/com/study/bookcafe/borrow/MapperTest.java
@@ -2,9 +2,7 @@ package com.study.bookcafe.borrow;
 
 import com.google.gson.Gson;
 import com.study.bookcafe.common.JsonHelper;
-import com.study.bookcafe.domain.Book;
-import com.study.bookcafe.domain.Borrow;
-import com.study.bookcafe.domain.Member;
+import com.study.bookcafe.domain.*;
 import com.study.bookcafe.dto.BookDto;
 import com.study.bookcafe.dto.BorrowDto;
 import com.study.bookcafe.dto.MemberDto;
@@ -18,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.*;
@@ -42,7 +39,7 @@ public class MapperTest {
             return Borrow.builder()
                     .member(Member.builder().id(1).build())
                     .book(Book.builder().id(1).ISBN(9788936433598L).build())
-                    .period(new Period(LocalDateTime.now()))
+                    .period(Period.createPeriod(LocalDateTime.now(), Level.BASIC))
                     .build();
         }
 
@@ -51,7 +48,7 @@ public class MapperTest {
             return BorrowDto.builder()
                     .member(MemberDto.builder().id(1).build())
                     .book(BookDto.builder().id(1).ISBN(9788936433598L).build())
-                    .period(new Period(LocalDateTime.now()))
+                    .period(Period.createPeriod(LocalDateTime.now(), Level.BASIC))
                     .build();
         }
 
@@ -60,7 +57,7 @@ public class MapperTest {
             return BorrowEntity.builder()
                     .member(MemberEntity.builder().id(1).build())
                     .book(BookEntity.builder().id(1).ISBN(9788936433598L).build())
-                    .period(new Period(LocalDateTime.now()))
+                    .period(Period.createPeriod(LocalDateTime.now(), Level.BASIC))
                     .build();
         }
     }

--- a/src/test/java/com/study/bookcafe/borrow/MapperTest.java
+++ b/src/test/java/com/study/bookcafe/borrow/MapperTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -39,7 +39,7 @@ public class MapperTest {
             return Borrow.builder()
                     .member(Member.builder().id(1).build())
                     .book(Book.builder().id(1).ISBN(9788936433598L).build())
-                    .period(Period.createPeriod(LocalDateTime.now(), Level.BASIC))
+                    .period(Period.of(LocalDate.now(), Level.BASIC))
                     .build();
         }
 
@@ -48,7 +48,7 @@ public class MapperTest {
             return BorrowDto.builder()
                     .member(MemberDto.builder().id(1).build())
                     .book(BookDto.builder().id(1).ISBN(9788936433598L).build())
-                    .period(Period.createPeriod(LocalDateTime.now(), Level.BASIC))
+                    .period(Period.of(LocalDate.now(), Level.BASIC))
                     .build();
         }
 
@@ -57,7 +57,7 @@ public class MapperTest {
             return BorrowEntity.builder()
                     .member(MemberEntity.builder().id(1).build())
                     .book(BookEntity.builder().id(1).ISBN(9788936433598L).build())
-                    .period(Period.createPeriod(LocalDateTime.now(), Level.BASIC))
+                    .period(Period.of(LocalDate.now(), Level.BASIC))
                     .build();
         }
     }

--- a/src/test/java/com/study/bookcafe/borrow/PeriodTest.java
+++ b/src/test/java/com/study/bookcafe/borrow/PeriodTest.java
@@ -4,18 +4,18 @@ import com.study.bookcafe.vo.Period;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.*;
 
 public class PeriodTest {
 
-    LocalDateTime date1 = LocalDateTime.of(2024, 12, 7, 12, 0, 0);
-    LocalDateTime date2 = LocalDateTime.of(2024, 12, 8, 12, 0, 0);
+    LocalDate date1 = LocalDate.of(2024, 12, 7);
+    LocalDate date2 = LocalDate.of(2024, 12, 8);
 
     @Test
     @DisplayName("반납일자는 대출일자보다 이후여야 한다.")
-    public void createPeriodTest() {
+    public void ofTest() {
         Period period1 = new Period(date1, date2);
         Period period2 = new Period(date2, date2);
 
@@ -25,7 +25,7 @@ public class PeriodTest {
 
     @Test
     @DisplayName("반납일자가 대출일자보다 이전이거나 반납일자 또는 대출일자가 null이면 예외가 발생한다.")
-    public void createPeriodExceptionTest() {
+    public void ofExceptionTest() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> new Period(date2, date1));
         Assertions.assertThrows(NullPointerException.class, () -> new Period(null, null));
     }


### PR DESCRIPTION
기존의 LocalDateTime 인자 하나만 받는 생성자는 함수에 대한 설명이 부족하여 정적 팩토리 메서드를 통해 생성하도록 변경
- `createPeriod()`에 회원의 등급을 인자로 받아 회원 별로 다를 수 있는 대출 기간을 객체 생성 시에 적용하도록 함
