### PR TITLE
this 제거 및 필드 직접 접근

### DIFF
--- a/src/main/java/com/study/bookcafe/domain/book/BookInventory.java
+++ b/src/main/java/com/study/bookcafe/domain/book/BookInventory.java
@@ -30,11 +30,15 @@ public class BookInventory {
      * @return 현재 도서의 대출 가능한 재고가 있는지 여부
      */
     public boolean isBorrowable() {
-        return this.isOnStock();
+        return isOnStock();
     }
 
     private boolean isOnStock() {
         return stock - borrowedCount > 0;
+    }
+
+    public boolean haveBorrowedCount() {
+        return borrowedCount > 0;
     }
 
     public boolean haveReservedCount() {
@@ -44,23 +48,24 @@ public class BookInventory {
     public void increaseBorrowedCount() {
         if (!isBorrowable()) throw new IllegalStateException("해당 도서는 이미 모두 대출되었습니다.");
 
-        this.borrowedCount++;
+        borrowedCount++;
     }
 
     public void increaseReservedCount() {
         if (MAXIMUM_RESERVATION_COUNT - reservedCount <= 0) throw new IllegalStateException("해당 도서에 대한 예약이 모두 찼습니다.");
 
-        this.reservedCount++;
+        reservedCount++;
+    }
+
+    public void decreaseBorrowedCount() {
+        if (!haveBorrowedCount()) throw new IllegalStateException("해당 도서에 대한 대출이 없습니다.");
+
+        borrowedCount--;
     }
 
     public void decreaseReservedCount() {
-        if (!this.haveReservedCount()) throw new IllegalStateException("해당 도서에 대한 예약이 없습니다.");
+        if (!haveReservedCount()) throw new IllegalStateException("해당 도서에 대한 예약이 없습니다.");
 
-        this.reservedCount--;
-    }
-
-    // 테스트
-    public void decreaseBorrowedCount() {
-        this.borrowedCount--;
+        reservedCount--;
     }
 }

--- a/src/main/java/com/study/bookcafe/domain/borrow/BorrowPeriod.java
+++ b/src/main/java/com/study/bookcafe/domain/borrow/BorrowPeriod.java
@@ -11,14 +11,14 @@ public class BorrowPeriod {
     DatePeriod period;
     Level level;
 
-    public static BorrowPeriod of(@NonNull LocalDate from, @NonNull Level level) {
+    public static BorrowPeriod of(@NonNull final LocalDate from, @NonNull final Level level) {
         return new BorrowPeriod(from, level);
     }
-    public static BorrowPeriod of(@NonNull DatePeriod period, @NonNull Level level) {
+    public static BorrowPeriod of(@NonNull final DatePeriod period, @NonNull final Level level) {
         return new BorrowPeriod(period, level);
     }
 
-    private BorrowPeriod(@NonNull LocalDate from, @NonNull Level level) {
+    private BorrowPeriod(@NonNull final LocalDate from, @NonNull final Level level) {
         try {
             this.period = new DatePeriod(from, from.plusWeeks(level.getBorrowPeriod()));
             this.level = level;
@@ -27,7 +27,7 @@ public class BorrowPeriod {
         }
     }
 
-    private BorrowPeriod(@NonNull DatePeriod period, @NonNull Level level) {
+    private BorrowPeriod(@NonNull final DatePeriod period, @NonNull final Level level) {
         this.period = period;
         this.level = level;
     }

--- a/src/main/java/com/study/bookcafe/domain/borrow/PriorityBorrowRight.java
+++ b/src/main/java/com/study/bookcafe/domain/borrow/PriorityBorrowRight.java
@@ -1,5 +1,6 @@
 package com.study.bookcafe.domain.borrow;
 
+import lombok.NonNull;
 import lombok.Value;
 
 import java.time.LocalDateTime;
@@ -11,19 +12,19 @@ public class PriorityBorrowRight {
 
     static final int DAY_EXPIRATION_DATE = 2;
 
-    public PriorityBorrowRight(final long bookId, final LocalDateTime from) {
+    public PriorityBorrowRight(final long bookId, @NonNull final LocalDateTime from) {
         this.bookId = bookId;
         this.period = new DateTimePeriod(from, from.plusDays(DAY_EXPIRATION_DATE));
     }
 
-    public PriorityBorrowRight(final long bookId, final DateTimePeriod period) {
+    public PriorityBorrowRight(final long bookId, @NonNull final DateTimePeriod period) {
         if(!period.equalsToDays(DAY_EXPIRATION_DATE)) throw new IllegalArgumentException("우선대출권의 유효기간은 2일입니다.");
 
         this.bookId = bookId;
         this.period = period;
     }
 
-    public boolean validateExpirationDate(final LocalDateTime date) {
+    public boolean validateExpirationDate(@NonNull final LocalDateTime date) {
         return period.includes(date);
     }
 }

--- a/src/main/java/com/study/bookcafe/domain/member/Level.java
+++ b/src/main/java/com/study/bookcafe/domain/member/Level.java
@@ -36,13 +36,13 @@ public enum Level {
     public boolean isBorrowCountLeft(final int borrowCount) {
         if (borrowCount < 0) throw new IllegalArgumentException("대출 권수는 0보다 작을 수 없습니다.");
 
-        return this.maximumBorrowCount - borrowCount > 0;
+        return maximumBorrowCount - borrowCount > 0;
     }
 
     public boolean isReservationCountLeft(final int reservationCount) {
         if (reservationCount < 0) throw new IllegalArgumentException("예약 권수는 0보다 작을 수 없습니다.");
 
-        return this.maximumReservationCount - reservationCount > 0;
+        return maximumReservationCount - reservationCount > 0;
     }
 
     /**
@@ -52,7 +52,7 @@ public enum Level {
      * @return 회원의 최대 대출 연장 횟수 - 회원의 연장한 횟수
      */
     public boolean haveExtendableCount(final int extendedCount) {
-        return this.maximumExtendCount - extendedCount > 0;
+        return maximumExtendCount - extendedCount > 0;
     }
 
 }

--- a/src/main/java/com/study/bookcafe/domain/member/Member.java
+++ b/src/main/java/com/study/bookcafe/domain/member/Member.java
@@ -4,6 +4,8 @@ import com.study.bookcafe.domain.borrow.PriorityBorrowRight;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
+
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,40 +33,50 @@ public class Member {
      * @return 현재 회원의 대출 가능 권수가 남았는지 여부
      */
     public boolean isBorrowable() {
-        return this.getLevel().isBorrowCountLeft(getBorrowCount());
+        return level.isBorrowCountLeft(borrowCount);
     }
 
     public boolean isReservable() {
-        return this.getLevel().isReservationCountLeft(getReservationCount());
+        return level.isReservationCountLeft(reservationCount);
     }
 
     public void increaseBorrowCount() {
-        if (!this.isBorrowable()) throw new IllegalStateException("회원의 대출 가능 권수가 없습니다.");
+        if (!isBorrowable()) throw new IllegalStateException("회원의 대출 가능 권수가 없습니다.");
 
-        this.borrowCount++;
+        borrowCount++;
     }
 
     public void increaseReservationCount() {
-        if (!this.isReservable()) throw new IllegalStateException("회원의 예약 가능 권수가 없습니다.");
+        if (!isReservable()) throw new IllegalStateException("회원의 예약 가능 권수가 없습니다.");
 
-        this.reservationCount++;
+        reservationCount++;
+    }
+
+    public void decreaseBorrowCount() {
+        if (!haveBorrowCount()) throw new IllegalStateException("회원의 대출 건수가 없습니다.");
+
+        borrowCount--;
     }
 
     public void decreaseReservationCount() {
-        if (!this.haveReservationCount()) throw new IllegalStateException("회원의 예약 건수가 없습니다.");
+        if (!haveReservationCount()) throw new IllegalStateException("회원의 예약 건수가 없습니다.");
 
-        this.reservationCount--;
+        reservationCount--;
+    }
+
+    public boolean haveBorrowCount() {
+        return borrowCount > 0;
     }
 
     public boolean haveReservationCount() {
-        return getReservationCount() > 0;
+        return reservationCount > 0;
     }
 
-    public void grant(PriorityBorrowRight priorityBorrowRight) {
+    public void grant(@NonNull final PriorityBorrowRight priorityBorrowRight) {
         priorityBorrowRightsMap.put(priorityBorrowRight.getBookId(), priorityBorrowRight);
     }
 
-    public boolean validatePriorityBorrowForBook(long bookId, LocalDateTime now) {
+    public boolean validatePriorityBorrowForBook(final long bookId, @NonNull final LocalDateTime now) {
         return priorityBorrowRightsMap.containsKey(bookId) && priorityBorrowRightsMap.get(bookId).validateExpirationDate(now);
     }
 

--- a/src/main/java/com/study/bookcafe/domain/reservation/Reservation.java
+++ b/src/main/java/com/study/bookcafe/domain/reservation/Reservation.java
@@ -5,6 +5,7 @@ import com.study.bookcafe.domain.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 
 import java.time.LocalDateTime;
 
@@ -18,11 +19,11 @@ public class Reservation {
     private LocalDateTime time;     // 예약 시간
     private int order;              // 예약 순서
 
-    public static Reservation of(final Member member, final BookInventory book) {
+    public static Reservation of(@NonNull final Member member, @NonNull final BookInventory book) {
         return new Reservation(member, book);
     }
 
-    private Reservation(final Member member, final BookInventory book) {
+    private Reservation(@NonNull final Member member, @NonNull final BookInventory book) {
         if (book.isBorrowable()) {
             if (member.isBorrowable()) throw new IllegalStateException("해당 도서는 대출 가능한 상태입니다.");
             // 도서가 대출 가능한 상태일 경우, 예약은 불가능


### PR DESCRIPTION
- 객체 내부에서 멤버 접근 시 this를 사용하지 않음
  - 메서드의 인자와 필드를 구분할 일이 없을 때는 this를 제거함
- 객체 내부에서 필드 접근 시 getter가 아닌 직접 접근
  - getter 접근 시 장점
    - getter를 통해 접근이 가능하여 한 곳에서 관리가 가능하여 데이터 핸들링이나 추가적인 작업 처리가 용이함
  - 직접 접근 시 장점
    - 코드가 직관적이라 가독성이 좋음

getter를 통해 데이터 핸들링이나 작업 처리가 가능하지만 추가 작업 처리가 필요하지 않을 경우도 있다고 생각합니다. 또한 추가 작업 처리가 필요할 때는 별도의 메서드(명확한 의도를 나타내는)를 생성해서 사용하는 것이 더 낫다고 생각합니다. 

그래서 굳이 불필요하게 getter를 사용하기보다 직접 접근하도록 변경했습니다. (자바 라이브러리들도 직접 접근하는 코드가 많이 보였습니다.)


Q. 객체 내부에서 this 사용은 일반적으로 컨벤션에 따라 다른지 궁금합니다.