### PR TITLE
회원의 우선대출권 포기 기능 추가

### DIFF
--- a/src/main/java/com/study/bookcafe/application/command/borrow/BorrowService.java
+++ b/src/main/java/com/study/bookcafe/application/command/borrow/BorrowService.java
@@ -11,5 +11,5 @@ public interface BorrowService {
     void borrow(long memberId, long bookId);
     void extend(long memberId, long bookId);
     void returnBook(long memberId, long bookId);
-
+    void relinquish(long memberId, long bookId);
 }

--- a/src/main/java/com/study/bookcafe/domain/borrow/DateTimePeriod.java
+++ b/src/main/java/com/study/bookcafe/domain/borrow/DateTimePeriod.java
@@ -19,7 +19,7 @@ public class DateTimePeriod {
     }
 
     public boolean includes(@NonNull final LocalDateTime date) {
-        return from.isBefore(date) && to.isAfter(date);
+        return !from.isAfter(date) && !to.isBefore(date);
     }
 
     public boolean equalsToDays(final int between) {

--- a/src/main/java/com/study/bookcafe/domain/member/Member.java
+++ b/src/main/java/com/study/bookcafe/domain/member/Member.java
@@ -76,6 +76,12 @@ public class Member {
         priorityBorrowRightsMap.put(priorityBorrowRight.getBookId(), priorityBorrowRight);
     }
 
+    public void revoke(final long bookId) {
+        if (!priorityBorrowRightsMap.containsKey(bookId)) throw new IllegalStateException("해당 도서에 대한 우선대출권을 보유하고 있지 않습니다.");
+
+        priorityBorrowRightsMap.remove(bookId);
+    }
+
     public boolean validatePriorityBorrowForBook(final long bookId, @NonNull final LocalDateTime now) {
         return priorityBorrowRightsMap.containsKey(bookId) && priorityBorrowRightsMap.get(bookId).validateExpirationDate(now);
     }

--- a/src/main/java/com/study/bookcafe/infrastructure/query/borrow/BorrowTestSets.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/borrow/BorrowTestSets.java
@@ -98,4 +98,23 @@ public class BorrowTestSets {
             .order(1)
             .build();
 
+    public static Borrow createBasicVegetarianBorrow() {
+        return Borrow.builder()
+                .id(1)
+                .member(MemberTestSets.createBasicMember())
+                .book(BookTestSets.createVegetarianBookInventory())
+                .borrowPeriod(BASIC_PERIOD)
+                .time(now)
+                .build();
+    }
+
+    public static Borrow createWormWhiteBorrow() {
+        return Borrow.builder()
+                .id(2)
+                .member(MemberTestSets.createWormMember())
+                .book(BookTestSets.createWhiteBookInventory())
+                .borrowPeriod(WORM_PERIOD)
+                .time(now)
+                .build();
+    }
 }

--- a/src/main/java/com/study/bookcafe/infrastructure/query/borrow/PriorityBorrowRightTestSets.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/borrow/PriorityBorrowRightTestSets.java
@@ -1,0 +1,23 @@
+package com.study.bookcafe.infrastructure.query.borrow;
+
+import com.study.bookcafe.domain.borrow.PriorityBorrowRight;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PriorityBorrowRightTestSets {
+    public static final Map<Long, PriorityBorrowRight> WORM_PRIORITY_BORROW_RIGHT_MAP = new HashMap<>(){{
+        put(2L, WORM_WHITE_PRIORITY_BORROW_RIGHT);
+    }};
+
+    public static final PriorityBorrowRight WORM_WHITE_PRIORITY_BORROW_RIGHT = new PriorityBorrowRight(2L, LocalDateTime.now().minusHours(1));
+
+    public static Map<Long, PriorityBorrowRight> createWormPriorityBorrowRightMap = new HashMap<>(){{
+        put(2L, createWormWhitePriorityBorrowRight());
+    }};
+
+    public static PriorityBorrowRight createWormWhitePriorityBorrowRight() {
+        return new PriorityBorrowRight(2L, LocalDateTime.now().minusHours(1));
+    }
+}

--- a/src/main/java/com/study/bookcafe/infrastructure/query/member/MemberTestSets.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/member/MemberTestSets.java
@@ -2,6 +2,7 @@ package com.study.bookcafe.infrastructure.query.member;
 
 import com.study.bookcafe.domain.member.Level;
 import com.study.bookcafe.domain.member.Member;
+import com.study.bookcafe.infrastructure.query.borrow.PriorityBorrowRightTestSets;
 import com.study.bookcafe.interfaces.member.MemberDto;
 import com.study.bookcafe.query.member.MemberView;
 
@@ -27,7 +28,7 @@ public class MemberTestSets {
         return Member.builder().id(1L).name("슈카").level(Level.BASIC).borrowCount(0).reservationCount(1).build();
     }
     public static Member createWormMember() {
-        return Member.builder().id(2L).name("머스크").level(Level.WORM).borrowCount(3).reservationCount(2).build();
+        return Member.builder().id(2L).name("머스크").level(Level.WORM).borrowCount(3).reservationCount(2).priorityBorrowRightsMap(PriorityBorrowRightTestSets.createWormPriorityBorrowRightMap).build();
     }
     public static Member createLibrarianMember() {
         return Member.builder().id(3L).name("트럼프").level(Level.LIBRARIAN).borrowCount(5).build();


### PR DESCRIPTION
우선대출권 포기 기능
- 회원은 회원에게 부여된 우선대출권을 포기할 수 있음
- 포기하면 다음 우선순위의 회원에게 우선대출권 부여

대출 테스트 mock 객체 설정 변경
- @BeforeAll이었던 mock 객체 설정로 인해 테스트 인스턴스들이 같은 mock 객체 동작을 공유하는 문제가 발생하여 @BeforeEach로 변경

기간 객체(DateTimePeriod)의 포함 범위 변경
- from과 to 사이뿐만 아니라 from과 to도 포함시키도록 변경
  - from <= target <= to