### PR TITLE
우선대출예약 건수 상태 추가 및 VO의 Entity Model 추가

### DIFF
--- a/src/main/java/com/study/bookcafe/application/command/book/BookInventoryService.java
+++ b/src/main/java/com/study/bookcafe/application/command/book/BookInventoryService.java
@@ -7,5 +7,6 @@ public interface BookInventoryService {
     // 도서 조회 (id)
     BookInventory findById(long id);
     BookInventory findByBookId(long bookId);
+    void update(BookInventory bookInventory);
 
 }

--- a/src/main/java/com/study/bookcafe/application/command/book/BookInventoryServiceImpl.java
+++ b/src/main/java/com/study/bookcafe/application/command/book/BookInventoryServiceImpl.java
@@ -22,4 +22,9 @@ public class BookInventoryServiceImpl implements BookInventoryService {
     public BookInventory findByBookId(long bookId) {
         return bookInventoryRepository.findByBookId(bookId).orElseThrow(() -> new IllegalArgumentException("도서 정보를 찾을 수 없습니다."));
     }
+
+    @Override
+    public void update(BookInventory bookInventory) {
+        bookInventoryRepository.update(bookInventory);
+    }
 }

--- a/src/main/java/com/study/bookcafe/domain/book/BookInventory.java
+++ b/src/main/java/com/study/bookcafe/domain/book/BookInventory.java
@@ -21,8 +21,10 @@ public class BookInventory {
     private int borrowedCount;              // 대출 건수
     @PositiveOrZero(message = "예약 건수는 0 이상이어야 합니다.")
     private int reservedCount;              // 예약 건수
+    @PositiveOrZero(message = "우선대출예약 건수는 0 이상이어야 합니다.")
+    private int priorityBorrowCount;        // 우선대출예약 건수
 
-    private final int MAXIMUM_RESERVATION_COUNT = 5;
+    private static final int MAXIMUM_RESERVATION_COUNT = 5;
 
     /**
      * 도서가 대출 가능한 상태인지 확인한다.
@@ -30,11 +32,7 @@ public class BookInventory {
      * @return 현재 도서의 대출 가능한 재고가 있는지 여부
      */
     public boolean isBorrowable() {
-        return isOnStock();
-    }
-
-    private boolean isOnStock() {
-        return stock - borrowedCount > 0;
+        return stock - borrowedCount - priorityBorrowCount > 0;
     }
 
     public boolean haveBorrowedCount() {
@@ -57,6 +55,12 @@ public class BookInventory {
         reservedCount++;
     }
 
+    public void increasePriorityBorrowCount() {
+        if (priorityBorrowCount > stock) throw new IllegalStateException("우선대출예약 건수는 재고와 같거나 이하여야 합니다.");
+
+        priorityBorrowCount++;
+    }
+
     public void decreaseBorrowedCount() {
         if (!haveBorrowedCount()) throw new IllegalStateException("해당 도서에 대한 대출이 없습니다.");
 
@@ -67,5 +71,13 @@ public class BookInventory {
         if (!haveReservedCount()) throw new IllegalStateException("해당 도서에 대한 예약이 없습니다.");
 
         reservedCount--;
+    }
+
+    public void decreasePriorityBorrowCount() {
+        priorityBorrowCount--;
+    }
+
+    public int getBorrowableCount() {
+        return stock - borrowedCount;
     }
 }

--- a/src/main/java/com/study/bookcafe/domain/book/BookInventoryRepository.java
+++ b/src/main/java/com/study/bookcafe/domain/book/BookInventoryRepository.java
@@ -6,5 +6,6 @@ public interface BookInventoryRepository {
 
     Optional<BookInventory> findById(long id);
     Optional<BookInventory> findByBookId(long bookId);
+    void update(BookInventory bookInventory);
 
 }

--- a/src/main/java/com/study/bookcafe/domain/borrow/BorrowPeriod.java
+++ b/src/main/java/com/study/bookcafe/domain/borrow/BorrowPeriod.java
@@ -1,15 +1,15 @@
 package com.study.bookcafe.domain.borrow;
 
 import com.study.bookcafe.domain.member.Level;
-import jakarta.persistence.Embedded;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import java.time.LocalDate;
 
 @Value
+@Builder
 public class BorrowPeriod {
 
-    @Embedded
     DatePeriod period;
     Level level;
 

--- a/src/main/java/com/study/bookcafe/domain/borrow/DatePeriod.java
+++ b/src/main/java/com/study/bookcafe/domain/borrow/DatePeriod.java
@@ -1,17 +1,16 @@
 package com.study.bookcafe.domain.borrow;
 
-import jakarta.persistence.Column;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
 import java.time.LocalDate;
 
 @Value
+@Builder
 public class DatePeriod {
 
-    @Column(name = "\"from\"")
     LocalDate from;           // 시작 일자
-    @Column(name = "\"to\"")
     LocalDate to;             // 종료 일자
 
     public static DatePeriod of(@NonNull final LocalDate from, final int weeks) {

--- a/src/main/java/com/study/bookcafe/domain/borrow/DateTimePeriod.java
+++ b/src/main/java/com/study/bookcafe/domain/borrow/DateTimePeriod.java
@@ -1,17 +1,16 @@
 package com.study.bookcafe.domain.borrow;
 
-import jakarta.persistence.Column;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
 import java.time.LocalDateTime;
 
 @Value
+@Builder
 public class DateTimePeriod {
 
-    @Column(name = "\"from\"")
     LocalDateTime from;
-    @Column(name = "\"to\"")
     LocalDateTime to;
 
     public static DateTimePeriod of(@NonNull final LocalDateTime from, final int days) {

--- a/src/main/java/com/study/bookcafe/infrastructure/command/book/JpaBookInventoryRepository.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/command/book/JpaBookInventoryRepository.java
@@ -1,0 +1,47 @@
+package com.study.bookcafe.infrastructure.command.book;
+
+import com.study.bookcafe.domain.book.BookInventory;
+import com.study.bookcafe.domain.book.BookInventoryRepository;
+import com.study.bookcafe.infrastructure.query.book.BookInventoryEntity;
+import com.study.bookcafe.interfaces.book.BookMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@Profile("jpa")
+public class JpaBookInventoryRepository implements BookInventoryRepository {
+
+    private final BookMapper bookMapper;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public JpaBookInventoryRepository(BookMapper bookMapper) {
+        this.bookMapper = bookMapper;
+    }
+
+    @Override
+    public Optional<BookInventory> findById(long id) {
+        return Optional.ofNullable(em.find(BookInventoryEntity.class, id))
+                .map(bookMapper::toBookInventory);
+    }
+
+    @Override
+    public Optional<BookInventory> findByBookId(long bookId) {
+        return em
+                .createQuery("SELECT b FROM book b WHERE b.bookId = :bookId", BookInventoryEntity.class)
+                .setParameter("bookId", bookId)
+                .getResultStream()
+                .findAny()
+                .map(bookMapper::toBookInventory);
+    }
+
+    @Override
+    public void update(BookInventory bookInventory) {
+        em.merge(bookMapper.toBookInventoryEntity(bookInventory));
+    }
+}

--- a/src/main/java/com/study/bookcafe/infrastructure/query/book/BookInventoryEntity.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/book/BookInventoryEntity.java
@@ -22,4 +22,5 @@ public class BookInventoryEntity {
     private int stock;                      // 재고
     private int borrowedCount;              // 대출 건수
     private int reservedCount;              // 예약 건수
+    private int priorityBorrowCount;        // 우선대출예약 건수
 }

--- a/src/main/java/com/study/bookcafe/infrastructure/query/borrow/BorrowEntity.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/borrow/BorrowEntity.java
@@ -1,12 +1,8 @@
 package com.study.bookcafe.infrastructure.query.borrow;
 
-import com.study.bookcafe.domain.borrow.BorrowPeriod;
 import com.study.bookcafe.infrastructure.query.book.BookInventoryEntity;
 import com.study.bookcafe.infrastructure.query.member.MemberEntity;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -18,16 +14,17 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class BorrowEntity {
     @Id
-    private long id;                        // 대출 ID
+    private long id;                            // 대출 ID
     @NonNull
-    @OneToOne
-    private MemberEntity member;            // 회원
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemberEntity member;                // 회원
     @NonNull
-    @OneToOne
-    private BookInventoryEntity book;       // 도서
+    @ManyToOne(fetch = FetchType.LAZY)
+    private BookInventoryEntity book;           // 도서
     @NonNull
-    private LocalDateTime time;             // 대출 시간
+    private LocalDateTime time;                 // 대출 시간
     @Embedded
-    private BorrowPeriod borrowPeriod;      // 대출 기간
-    private int extensionCount;             // 대출 연장한 횟수
+    private BorrowPeriodEntity borrowPeriod;    // 대출 기간
+    private int extensionCount;                 // 대출 연장한 횟수
+
 }

--- a/src/main/java/com/study/bookcafe/infrastructure/query/borrow/BorrowPeriodEntity.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/borrow/BorrowPeriodEntity.java
@@ -1,0 +1,21 @@
+package com.study.bookcafe.infrastructure.query.borrow;
+
+import com.study.bookcafe.domain.member.Level;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.*;
+
+@Embeddable
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class BorrowPeriodEntity {
+
+    @Embedded
+    DatePeriodEntity period;
+    @Enumerated(EnumType.STRING)
+    Level level;
+}

--- a/src/main/java/com/study/bookcafe/infrastructure/query/borrow/DatePeriodEntity.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/borrow/DatePeriodEntity.java
@@ -1,0 +1,19 @@
+package com.study.bookcafe.infrastructure.query.borrow;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Embeddable
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DatePeriodEntity {
+    @Column(name = "\"from\"")
+    LocalDate from;           // 시작 일자
+    @Column(name = "\"to\"")
+    LocalDate to;             // 종료 일자
+}

--- a/src/main/java/com/study/bookcafe/infrastructure/query/borrow/DateTimePeriodEntity.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/borrow/DateTimePeriodEntity.java
@@ -1,0 +1,19 @@
+package com.study.bookcafe.infrastructure.query.borrow;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Embeddable
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DateTimePeriodEntity {
+    @Column(name = "\"from\"")
+    LocalDateTime from;
+    @Column(name = "\"to\"")
+    LocalDateTime to;
+}

--- a/src/main/java/com/study/bookcafe/infrastructure/query/borrow/PriorityBorrowPeriodEntity.java
+++ b/src/main/java/com/study/bookcafe/infrastructure/query/borrow/PriorityBorrowPeriodEntity.java
@@ -1,0 +1,15 @@
+package com.study.bookcafe.infrastructure.query.borrow;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.*;
+
+@Embeddable
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PriorityBorrowPeriodEntity {
+    @Embedded
+    DateTimePeriodEntity period;
+}

--- a/src/main/java/com/study/bookcafe/interfaces/book/BookInventoryDto.java
+++ b/src/main/java/com/study/bookcafe/interfaces/book/BookInventoryDto.java
@@ -12,4 +12,5 @@ public class BookInventoryDto {
     private int stock;                      // 재고
     private int borrowedCount;              // 대출 건수
     private int reservedCount;              // 예약 건수
+    private int priorityBorrowCount;        // 우선대출예약 건수
 }

--- a/src/main/java/com/study/bookcafe/interfaces/book/BookMapper.java
+++ b/src/main/java/com/study/bookcafe/interfaces/book/BookMapper.java
@@ -21,6 +21,7 @@ public interface BookMapper {
     @Mapping(target = "stock", source = "stock")
     @Mapping(target = "borrowedCount", source = "borrowedCount")
     @Mapping(target = "reservedCount", source = "reservedCount")
+    @Mapping(target = "priorityBorrowCount", source = "priorityBorrowCount")
     BookInventoryDto toBookInventoryDto(BookInventory bookInventory);
 
     // BookInventoryDto -> BookInventory
@@ -31,6 +32,7 @@ public interface BookMapper {
     @Mapping(target = "stock", source = "stock")
     @Mapping(target = "borrowedCount", source = "borrowedCount")
     @Mapping(target = "reservedCount", source = "reservedCount")
+    @Mapping(target = "priorityBorrowCount", source = "priorityBorrowCount")
     BookInventory toBookInventory(BookInventoryDto bookInventoryDto);
 
     // BookInventory -> BookInventoryEntity
@@ -41,6 +43,7 @@ public interface BookMapper {
     @Mapping(target = "stock", source = "stock")
     @Mapping(target = "borrowedCount", source = "borrowedCount")
     @Mapping(target = "reservedCount", source = "reservedCount")
+    @Mapping(target = "priorityBorrowCount", source = "priorityBorrowCount")
     BookInventoryEntity toBookInventoryEntity(BookInventory bookInventory);
 
     // BookInventoryEntity -> BookInventory
@@ -51,6 +54,7 @@ public interface BookMapper {
     @Mapping(target = "stock", source = "stock")
     @Mapping(target = "borrowedCount", source = "borrowedCount")
     @Mapping(target = "reservedCount", source = "reservedCount")
+    @Mapping(target = "priorityBorrowCount", source = "priorityBorrowCount")
     BookInventory toBookInventory(BookInventoryEntity bookInventoryEntity);
 
 

--- a/src/main/java/com/study/bookcafe/interfaces/borrow/BorrowMapper.java
+++ b/src/main/java/com/study/bookcafe/interfaces/borrow/BorrowMapper.java
@@ -1,10 +1,9 @@
 package com.study.bookcafe.interfaces.borrow;
 
-import com.study.bookcafe.domain.borrow.Borrow;
-import com.study.bookcafe.infrastructure.query.borrow.BorrowEntity;
+import com.study.bookcafe.domain.borrow.*;
+import com.study.bookcafe.infrastructure.query.borrow.*;
 import com.study.bookcafe.interfaces.book.BookMapper;
 import com.study.bookcafe.interfaces.member.MemberMapper;
-import jdk.jfr.Name;
 import org.mapstruct.*;
 
 import java.util.List;
@@ -28,7 +27,7 @@ public interface BorrowMapper {
     BorrowDto toBorrowDto(Borrow borrow);
 
     // BorrowDto -> Borrow
-    @Name("BorrowDtoToBorrow")
+    @Named("BorrowDtoToBorrow")
     @Mapping(target = "id", source = "id")
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberDtoToMember"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookInventoryDtoToBookInventory"})
@@ -43,7 +42,7 @@ public interface BorrowMapper {
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberToMemberEntity"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookInventoryToBookInventoryEntity"})
     @Mapping(target = "time", source = "time")
-    @Mapping(target = "borrowPeriod", source = "borrowPeriod")
+    @Mapping(target = "borrowPeriod", source = "borrowPeriod", qualifiedByName = {"BorrowPeriodToBorrowPeriodEntity"})
     @Mapping(target = "extensionCount", source = "extensionCount")
     BorrowEntity toBorrowEntity(Borrow borrow);
 
@@ -53,7 +52,7 @@ public interface BorrowMapper {
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberEntityToMember"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookInventoryEntityToBookInventory"})
     @Mapping(target = "time", source = "time")
-    @Mapping(target = "borrowPeriod", source = "borrowPeriod")
+    @Mapping(target = "borrowPeriod", source = "borrowPeriod", qualifiedByName = {"BorrowPeriodEntityToBorrowPeriod"})
     @Mapping(target = "extensionCount", source = "extensionCount")
     Borrow toBorrow(BorrowEntity borrowEntity);
 
@@ -69,5 +68,50 @@ public interface BorrowMapper {
     @IterableMapping(qualifiedByName = "BorrowToBorrowDto")
     List<BorrowDto> toBorrowDtos(List<Borrow> borrows);
 
+    // DateTimePeriod -> DateTimePeriodEntity
+    @Named("DateTimePeriodToDateTimePeriodEntity")
+    @Mapping(target = "from", source = "from")
+    @Mapping(target = "to", source = "to")
+    DateTimePeriodEntity toDateTimePeriodEntity(DateTimePeriod dateTimePeriod);
+
+    // DateTimePeriodEntity -> DateTimePeriod
+    @Named("DateTimePeriodEntityToDateTimePeriod")
+    @Mapping(target = "from", source = "from")
+    @Mapping(target = "to", source = "to")
+    DateTimePeriod toDateTimePeriod(DateTimePeriodEntity dateTimePeriodEntity);
+
+    // DatePeriod -> DatePeriodEntity
+    @Named("DatePeriodToDatePeriodEntity")
+    @Mapping(target = "from", source = "from")
+    @Mapping(target = "to", source = "to")
+    DatePeriodEntity toDatePeriodEntity(DatePeriod datePeriod);
+
+    // DatePeriodEntity -> DatePeriod
+    @Named("DatePeriodEntityToDatePeriod")
+    @Mapping(target = "from", source = "from")
+    @Mapping(target = "to", source = "to")
+    DatePeriod toDatePeriod(DatePeriodEntity datePeriodEntity);
+
+    // BorrowPeriod -> BorrowPeriodEntity
+    @Named("BorrowPeriodToBorrowPeriodEntity")
+    @Mapping(target = "period", source = "period")
+    @Mapping(target = "level", source = "level")
+    BorrowPeriodEntity toBorrowPeriodEntity(BorrowPeriod borrowPeriod);
+
+    // BorrowPeriodEntity -> BorrowPeriod
+    @Named("BorrowPeriodEntityToBorrowPeriod")
+    @Mapping(target = "period", source = "period")
+    @Mapping(target = "level", source = "level")
+    BorrowPeriod toBorrowPeriod(BorrowPeriodEntity borrowPeriodEntity);
+
+    // PriorityBorrowPeriod -> PriorityBorrowPeriodEntity
+    @Named("PriorityBorrowPeriodToPriorityBorrowPeriodEntity")
+    @Mapping(target = "period", source = "period")
+    PriorityBorrowPeriodEntity toPriorityBorrowPeriodEntity(PriorityBorrowPeriod priorityBorrowPeriod);
+
+    // PriorityBorrowPeriodEntity -> PriorityBorrowPeriod
+    @Named("PriorityBorrowPeriodEntityToPriorityBorrowPeriod")
+    @Mapping(target = "period", source = "period")
+    PriorityBorrowPeriod toPriorityBorrowPeriod(PriorityBorrowPeriodEntity priorityBorrowPeriodEntity);
 
 }

--- a/src/main/java/com/study/bookcafe/interfaces/reservation/ReservationMapper.java
+++ b/src/main/java/com/study/bookcafe/interfaces/reservation/ReservationMapper.java
@@ -3,6 +3,7 @@ package com.study.bookcafe.interfaces.reservation;
 import com.study.bookcafe.domain.reservation.Reservation;
 import com.study.bookcafe.infrastructure.query.reservation.ReservationEntity;
 import com.study.bookcafe.interfaces.book.BookMapper;
+import com.study.bookcafe.interfaces.borrow.BorrowMapper;
 import com.study.bookcafe.interfaces.member.MemberMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -13,24 +14,24 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(
         componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
-        uses = {MemberMapper.class, BookMapper.class}
+        uses = {MemberMapper.class, BookMapper.class, BorrowMapper.class}
 )
 public interface ReservationMapper {
+    // ReservationEntity -> Reservation
     @Named("ReservationEntityToReservation")
     @Mapping(target = "id", source = "id")
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberEntityToMember"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookInventoryEntityToBookInventory"})
     @Mapping(target = "time", source = "time")
-    @Mapping(target = "priorityBorrowPeriod", source = "priorityBorrowPeriod")
-    // ReservationEntity -> Reservation
+    @Mapping(target = "priorityBorrowPeriod", source = "priorityBorrowPeriod", qualifiedByName = {"BorrowMapper", "PriorityBorrowPeriodEntityToPriorityBorrowPeriod"})
     Reservation toReservation(ReservationEntity reservationEntity);
 
+    // Reservation -> ReservationEntity
     @Named("ReservationToReservationEntity")
     @Mapping(target = "id", source = "id")
     @Mapping(target = "member", source = "member", qualifiedByName = {"MemberMapper", "MemberToMemberEntity"})
     @Mapping(target = "book", source = "book", qualifiedByName = {"BookMapper", "BookInventoryToBookInventoryEntity"})
     @Mapping(target = "time", source = "time")
-    @Mapping(target = "priorityBorrowPeriod", source = "priorityBorrowPeriod")
-    // Reservation -> ReservationEntity
+    @Mapping(target = "priorityBorrowPeriod", source = "priorityBorrowPeriod", qualifiedByName = {"BorrowMapper", "PriorityBorrowPeriodToPriorityBorrowPeriodEntity"})
     ReservationEntity toReservationEntity(Reservation reservation);
 }

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -13,5 +13,5 @@ VALUES
 -- reservation
 INSERT INTO reservation(id, member_id, book_id, time, "from", "to")
 VALUES
-    (1, 1, 1, '2025-05-03 15:00:00', NULL, NULL),
+    (1, 1, 1, '2025-05-03 15:00:00', '2025-05-10 12:00:00', '2025-05-12 12:00:00'),
     (2, 2, 1, '2025-05-03 16:00:00', NULL, NULL);


### PR DESCRIPTION
도서에 우선대출예약 건수 상태 추가 및 관리
- 도서가 대출가능한 상태인지 정확히 파악하려면 우선대출예약 건수도 필요함
  - 대출 가능한 도서 권수 (총 재고 - 대출 건수 - 우선대출예약 건수)
- 이에 따른 도서 update 로직 추가 및 JPA 구현

VO의 Entity Model 및 Mapper 추가
DB 더미 데이터 SQL 작성